### PR TITLE
removing 1e6 division in price plotting routine for tutorials

### DIFF
--- a/tutorial/utils/plotting.py
+++ b/tutorial/utils/plotting.py
@@ -110,7 +110,7 @@ class Plots(object):
                      values='lvl')
               .rename(columns={'lvl': 'value'})
               )
-        df = df / 8760 * 100 / 1e6 * self.cost_unit_conv
+        df = df / 8760 * 100 * self.cost_unit_conv
         df.plot.bar(stacked=False)
         plt.title('{} Energy System Prices'.format(self.country.title()))
         plt.ylabel('cents/kWhr')


### PR DESCRIPTION
To ensure that the reporting is consistent with the pull request on the Austria tutorial, the erroneous division of prices by 1e6 was removed from plotting.py.